### PR TITLE
fix: replace HTTP fetch with direct database queries in SMS endpoints

### DIFF
--- a/app/api/external-app/sms/rewardreach/route.ts
+++ b/app/api/external-app/sms/rewardreach/route.ts
@@ -147,16 +147,20 @@ async function processSmsInBackground(records: SmsRecord[], endpointName: string
     let totalSent = 0;
     const errors: string[] = [];
 
-    // FIX: Fetch message template ONCE before the loop
-    console.log('[SMS DEBUG] Fetching message template for batch...');
-    const activeMessageResponse = await fetch(`${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/sms-messages/active/rewardreach`);
-    const activeMessageData = await activeMessageResponse.json();
+    // FIX: Direct database query instead of HTTP request
+    console.log('[SMS DEBUG] Fetching message template from database...');
+    const activeMessage = await prisma.smsMessage.findFirst({
+      where: {
+        endpoint: 'rewardreach',
+        is_active: true
+      }
+    });
     
-    if (!activeMessageData.success || !activeMessageData.data) {
+    if (!activeMessage) {
       throw new Error('No active message found for rewardreach endpoint');
     }
 
-    const messageTemplate = activeMessageData.data.message;
+    const messageTemplate = activeMessage.message;
     const { processMessage } = await import('@/lib/messageProcessor');
     
     console.log('[SMS DEBUG] Message template loaded:', messageTemplate);

--- a/app/api/external-app/sms/unclaim/route.ts
+++ b/app/api/external-app/sms/unclaim/route.ts
@@ -149,16 +149,20 @@ async function processSmsInBackground(records: SmsRecord[], endpointName: string
     let totalSent = 0;
     const errors: string[] = [];
 
-    // FIX: Fetch message template ONCE before the loop
-    console.log('[SMS DEBUG] Fetching message template for batch...');
-    const activeMessageResponse = await fetch(`${process.env.NEXTAUTH_URL || 'http://localhost:3000'}/api/sms-messages/active/unclaim`);
-    const activeMessageData = await activeMessageResponse.json();
+    // FIX: Direct database query instead of HTTP request
+    console.log('[SMS DEBUG] Fetching message template from database...');
+    const activeMessage = await prisma.smsMessage.findFirst({
+      where: {
+        endpoint: 'unclaim',
+        is_active: true
+      }
+    });
     
-    if (!activeMessageData.success || !activeMessageData.data) {
+    if (!activeMessage) {
       throw new Error('No active message found for unclaim endpoint');
     }
 
-    const messageTemplate = activeMessageData.data.message;
+    const messageTemplate = activeMessage.message;
     const { processMessage } = await import('@/lib/messageProcessor');
     
     console.log('[SMS DEBUG] Message template loaded:', messageTemplate);


### PR DESCRIPTION
- Replace HTTP requests to self with direct Prisma database queries
- Fix timeout issues in SMS background processing
- Eliminate unnecessary network overhead for internal operations
- Improve performance and reliability of SMS message template fetching
- Fix ConnectTimeoutError in rewardreach and unclaim SMS endpoints
- Use direct database access instead of HTTP API calls for internal operations